### PR TITLE
Handle vedlegg dates without offset

### DIFF
--- a/msh-client/src/main/kotlin/no/ks/fiks/nhn/DateTimeUtils.kt
+++ b/msh-client/src/main/kotlin/no/ks/fiks/nhn/DateTimeUtils.kt
@@ -1,0 +1,25 @@
+package no.ks.fiks.nhn
+
+import mu.KotlinLogging
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneId
+import java.time.format.DateTimeParseException
+
+private val log = KotlinLogging.logger { }
+
+val DEFAULT_ZONE: ZoneId = ZoneId.of("Europe/Oslo")
+
+fun String.parseOffsetDateTimeOrNull(): OffsetDateTime? =
+    try {
+        OffsetDateTime.parse(this)
+    } catch (_: DateTimeParseException) {
+        try {
+            LocalDateTime.parse(this).atZone(DEFAULT_ZONE).toOffsetDateTime()
+        } catch (_: DateTimeParseException) {
+            log.warn { "Unable to parse date: $this" }
+            null
+        }
+    }
+
+

--- a/msh-client/src/main/kotlin/no/ks/fiks/nhn/DateTimeUtils.kt
+++ b/msh-client/src/main/kotlin/no/ks/fiks/nhn/DateTimeUtils.kt
@@ -14,12 +14,14 @@ fun String.parseOffsetDateTimeOrNull(): OffsetDateTime? =
     try {
         OffsetDateTime.parse(this)
     } catch (_: DateTimeParseException) {
-        try {
-            LocalDateTime.parse(this).atZone(DEFAULT_ZONE).toOffsetDateTime()
-        } catch (_: DateTimeParseException) {
-            log.warn { "Unable to parse date: $this" }
-            null
-        }
+        parseAsLocalDateTime()
     }
+
+private fun String.parseAsLocalDateTime(): OffsetDateTime? = try {
+    LocalDateTime.parse(this).atZone(DEFAULT_ZONE).toOffsetDateTime()
+} catch (_: DateTimeParseException) {
+    log.warn { "Unable to parse date: $this" }
+    null
+}
 
 

--- a/msh-client/src/main/kotlin/no/ks/fiks/nhn/edi/BusinessDocumentDeserializer.kt
+++ b/msh-client/src/main/kotlin/no/ks/fiks/nhn/edi/BusinessDocumentDeserializer.kt
@@ -7,14 +7,13 @@ import no.kith.xmlstds.msghead._2006_05_24.CV
 import no.kith.xmlstds.msghead._2006_05_24.Ident
 import no.kith.xmlstds.msghead._2006_05_24.MsgHead
 import no.ks.fiks.hdir.*
+import no.ks.fiks.nhn.DEFAULT_ZONE
 import no.ks.fiks.nhn.msh.*
+import no.ks.fiks.nhn.parseOffsetDateTimeOrNull
 import org.w3c.dom.Node
 import java.io.ByteArrayInputStream
 import java.io.StringReader
-import java.time.OffsetDateTime
-import java.time.ZoneId
-import java.util.GregorianCalendar
-import java.util.TimeZone
+import java.util.*
 import javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED
 import javax.xml.datatype.XMLGregorianCalendar
 import javax.xml.stream.XMLInputFactory
@@ -33,8 +32,6 @@ private const val MSG_HEAD_VERSION = "v1.2 2006-05-24"
 
 private const val APPREC_VERSION_1_0 = "1.0 2004-11-21"
 private const val APPREC_VERSION_1_1 = "v1.1 2012-02-15"
-
-private const val DEFAULT_ZONE = "Europe/Oslo"
 
 private val log = KotlinLogging.logger { }
 
@@ -245,7 +242,7 @@ object BusinessDocumentDeserializer {
 
     private fun Any?.getText() = (this as? Node)?.firstChild?.nodeValue
 
-    private fun XMLGregorianCalendar.toLocalDate() = toZonedDateTime().withZoneSameInstant(ZoneId.of(DEFAULT_ZONE)).toLocalDate()
+    private fun XMLGregorianCalendar.toLocalDate() = toZonedDateTime().withZoneSameInstant(DEFAULT_ZONE).toLocalDate()
 
     private fun XMLGregorianCalendar.toOffsetDateTime() = toZonedDateTime().toOffsetDateTime()
 
@@ -265,7 +262,7 @@ object BusinessDocumentDeserializer {
                     .also { if (it == null) log.info { "Ignoring ref doc of type ${refDoc.msgType.v}, as only 'A, Vedlegg' is supported" } }
                     ?.let {
                         IncomingVedlegg(
-                            date = refDoc.issueDate.v?.let { OffsetDateTime.parse(it) },
+                            date = refDoc.issueDate.v?.parseOffsetDateTimeOrNull(),
                             description = refDoc.description,
                             mimeType = refDoc.mimeType,
                             data = (refDoc.content.any.single() as? Base64Container)
@@ -275,6 +272,7 @@ object BusinessDocumentDeserializer {
                     }
             }
         }
+
     private fun MsgHead.getConversationRef() =
         if (msgInfo.conversationRef?.refToConversation.isNullOrBlank() && msgInfo.conversationRef?.refToParent.isNullOrBlank()) null
         else ConversationRef(refToParent = msgInfo.conversationRef?.refToParent, refToConversation = msgInfo.conversationRef?.refToConversation)

--- a/msh-client/src/main/kotlin/no/ks/fiks/nhn/msh/MshInternalClient.kt
+++ b/msh-client/src/main/kotlin/no/ks/fiks/nhn/msh/MshInternalClient.kt
@@ -22,13 +22,11 @@ import no.ks.fiks.helseid.dpop.Endpoint
 import no.ks.fiks.helseid.dpop.HttpMethod
 import no.ks.fiks.helseid.dpop.ProofBuilder
 import no.ks.fiks.helseid.http.DpopHttpRequestHelper
+import no.ks.fiks.nhn.parseOffsetDateTimeOrNull
 import no.nhn.msh.v2.model.*
 import no.nhn.msh.v2.model.Message
 import no.nhn.msh.v2.model.StatusInfo
-import java.time.LocalDateTime
 import java.time.OffsetDateTime
-import java.time.ZoneOffset
-import java.time.format.DateTimeParseException
 import java.util.*
 
 private const val API_VERSION_HEADER = "api-version"
@@ -255,24 +253,9 @@ private fun buildDefaultClient() =
                         override fun deserialize(
                             parser: JsonParser,
                             context: DeserializationContext
-                        ): OffsetDateTime? = parser.text.tryParseOffsetDateTime()
+                        ): OffsetDateTime? = parser.text.parseOffsetDateTimeOrNull()
                     })
                 })
             }
         }
     }
-
-private fun String.tryParseOffsetDateTime()  = try {
-    OffsetDateTime.parse(this)
-} catch (_: DateTimeParseException) {
-    tryParseOffsetDateTimeWithoutZone()
-}
-
-private fun String.tryParseOffsetDateTimeWithoutZone() = try {
-    val local = LocalDateTime.parse(this)
-    OffsetDateTime.of(local, ZoneOffset.UTC)
-} catch (_: DateTimeParseException) {
-    log.error { "Unable to parse date: $this" }
-    null
-}
-

--- a/msh-client/src/test/kotlin/no/ks/fiks/nhn/edi/BusinessDocumentDeserializerTest.kt
+++ b/msh-client/src/test/kotlin/no/ks/fiks/nhn/edi/BusinessDocumentDeserializerTest.kt
@@ -212,6 +212,47 @@ class BusinessDocumentDeserializerTest : StringSpec({
         }
     }
 
+    "Vedlegg date with UTC offset should be parsed correctly" {
+        BusinessDocumentDeserializer.deserializeMsgHead(
+            readResourceContentAsString("dialogmelding/1.0/foresporsel-og-svar/dialog-foresporsel-samsvar-test.xml")
+        ).asClue { it.vedlegg!!.date shouldBe OffsetDateTime.parse("2025-05-13T11:51:01.5833859Z") }
+    }
+
+    "Vedlegg date with specific positive offset should be parsed correctly" {
+        BusinessDocumentDeserializer.deserializeMsgHead(
+            readResourceContentAsString("dialogmelding/1.0/foresporsel-og-svar/dialog-foresporsel-samsvar-test.xml")
+                .replace("2025-05-13T11:51:01.5833859Z", "2025-06-14T01:02:03.123+05:00")
+        ).asClue { it.vedlegg!!.date shouldBe OffsetDateTime.of(2025, 6, 14, 1, 2, 3, 123000000, ZoneOffset.ofHours(5)) }
+    }
+
+    "Vedlegg date with specific negative offset should be parsed correctly" {
+        BusinessDocumentDeserializer.deserializeMsgHead(
+            readResourceContentAsString("dialogmelding/1.0/foresporsel-og-svar/dialog-foresporsel-samsvar-test.xml")
+                .replace("2025-05-13T11:51:01.5833859Z", "2025-06-14T01:02:03-04:00")
+        ).asClue { it.vedlegg!!.date shouldBe OffsetDateTime.of(2025, 6, 14, 1, 2, 3, 0, ZoneOffset.ofHours(-4)) }
+    }
+
+    "Vedlegg date without offset should be interpreted as Norwegian timezone (UTC+1 in winter)" {
+        BusinessDocumentDeserializer.deserializeMsgHead(
+            readResourceContentAsString("dialogmelding/1.0/foresporsel-og-svar/dialog-foresporsel-samsvar-test.xml")
+                .replace("2025-05-13T11:51:01.5833859Z", "2025-01-02T23:22:21")
+        ).asClue { it.vedlegg!!.date shouldBe OffsetDateTime.of(2025, 1, 2, 23, 22, 21, 0, ZoneOffset.ofHours(1)) }
+    }
+
+    "Vedlegg date without offset should be interpreted as Norwegian timezone (UTC+2 in summer)" {
+        BusinessDocumentDeserializer.deserializeMsgHead(
+            readResourceContentAsString("dialogmelding/1.0/foresporsel-og-svar/dialog-foresporsel-samsvar-test.xml")
+                .replace("2025-05-13T11:51:01.5833859Z", "2025-05-13T11:51:01")
+        ).asClue { it.vedlegg!!.date shouldBe OffsetDateTime.of(2025, 5, 13, 11, 51, 1, 0, ZoneOffset.ofHours(2)) }
+    }
+
+    "Invalid vedlegg date should give null" {
+        BusinessDocumentDeserializer.deserializeMsgHead(
+            readResourceContentAsString("dialogmelding/1.0/foresporsel-og-svar/dialog-foresporsel-samsvar-test.xml")
+                .replace("2025-05-13T11:51:01.5833859Z", "2025")
+        ).asClue { it.vedlegg!!.date should beNull() }
+    }
+
     "Should throw exception if version is invalid" {
         shouldThrow<IllegalArgumentException> {
             BusinessDocumentDeserializer.deserializeMsgHead(readResourceContentAsString("dialogmelding/invalid-version.xml"))

--- a/msh-client/src/test/kotlin/no/ks/fiks/nhn/msh/MshInternalClientTest.kt
+++ b/msh-client/src/test/kotlin/no/ks/fiks/nhn/msh/MshInternalClientTest.kt
@@ -388,7 +388,7 @@ class MshInternalClientTest : FreeSpec() {
                         it.receiverHerId shouldBe 8143060
                         it.senderHerId shouldBe 8094866
                         it.businessDocumentId shouldBe "c88389b7-f8ad-40b2-81e1-090e715b7530"
-                        it.businessDocumentGenDate shouldBe OffsetDateTime.parse("2025-08-21T11:39:57Z")
+                        it.businessDocumentGenDate shouldBe OffsetDateTime.parse("2025-08-21T11:39:57+02:00")
                         it.isAppRec shouldBe false
                     }
 
@@ -411,7 +411,7 @@ class MshInternalClientTest : FreeSpec() {
                         it.receiverHerId shouldBe 8143060
                         it.senderHerId shouldBe 8094866
                         it.businessDocumentId shouldBe "9ebaaf44-7317-41b7-892a-2a568acd5111"
-                        it.businessDocumentGenDate shouldBe OffsetDateTime.parse("2025-08-21T11:21:16.0004155Z")
+                        it.businessDocumentGenDate shouldBe OffsetDateTime.parse("2025-08-21T11:21:16.0004155+02:00")
                         it.isAppRec shouldBe true
                     }
             }
@@ -485,7 +485,7 @@ class MshInternalClientTest : FreeSpec() {
                         it.receiverHerId shouldBe 8143060
                         it.senderHerId shouldBe 8094866
                         it.businessDocumentId shouldBe "c88389b7-f8ad-40b2-81e1-090e715b7530"
-                        it.businessDocumentGenDate shouldBe OffsetDateTime.parse("2025-08-21T11:39:57Z")
+                        it.businessDocumentGenDate shouldBe OffsetDateTime.parse("2025-08-21T11:39:57+02:00")
                         it.isAppRec shouldBe false
                     }
             }


### PR DESCRIPTION
Spesifikasjonen sier ingenting om formatet på vedleggets `issueDate`. Samsvar gir datoer med offset, men fra testintegrasjon får vi uten. Må derfor håndtere begge deler.

Endret samtidig datohåndteringen for MSH-klienten til å også bruke norsk tid som fallback i stedet for UTC.