### PR TITLE
Support XHTML for Dialogmelding Notat

### DIFF
--- a/msh-client/src/main/kotlin/no/ks/fiks/nhn/edi/BusinessDocumentDeserializer.kt
+++ b/msh-client/src/main/kotlin/no/ks/fiks/nhn/edi/BusinessDocumentDeserializer.kt
@@ -10,7 +10,6 @@ import no.ks.fiks.hdir.*
 import no.ks.fiks.nhn.DEFAULT_ZONE
 import no.ks.fiks.nhn.msh.*
 import no.ks.fiks.nhn.parseOffsetDateTimeOrNull
-import org.w3c.dom.Node
 import java.io.ByteArrayInputStream
 import java.io.StringReader
 import java.util.*
@@ -33,11 +32,13 @@ private const val MSG_HEAD_VERSION = "v1.2 2006-05-24"
 private const val APPREC_VERSION_1_0 = "1.0 2004-11-21"
 private const val APPREC_VERSION_1_1 = "v1.1 2012-02-15"
 
+private const val TEKST_NOTAT_INNHOLD = "TekstNotatInnhold"
+
 private val log = KotlinLogging.logger { }
 
 object BusinessDocumentDeserializer {
 
-    private val factory = XMLInputFactory.newInstance()
+    private val inputFactory = XMLInputFactory.newInstance()
 
     fun deserializeMsgHead(msgHeadXml: String): IncomingBusinessDocument {
         validateRootElement(msgHeadXml, MSG_HEAD_ROOT)
@@ -51,7 +52,7 @@ object BusinessDocumentDeserializer {
             type = msgHead.getType(),
             sender = msgHead.getSender(),
             receiver = msgHead.getReceiver(),
-            message = msgHead.getMessage(),
+            message = msgHead.getMessage(msgHeadXml),
             vedlegg = msgHead.getVedlegg(),
             conversationRef = msgHead.getConversationRef(),
         )
@@ -79,7 +80,7 @@ object BusinessDocumentDeserializer {
     }
 
     private fun getVersion(xml: String): String? {
-        val reader = factory.createXMLStreamReader(StringReader(xml))
+        val reader = inputFactory.createXMLStreamReader(StringReader(xml))
 
         while (reader.hasNext()) {
             if (reader.next() == XMLStreamConstants.START_ELEMENT) {
@@ -93,7 +94,7 @@ object BusinessDocumentDeserializer {
     }
 
     private fun getRootElement(xml: String): String? {
-        val reader = factory.createXMLStreamReader(StringReader(xml))
+        val reader = inputFactory.createXMLStreamReader(StringReader(xml))
 
         var iterations = 0
         while (reader.hasNext() && reader.next() != XMLStreamConstants.START_ELEMENT && iterations < 100) {
@@ -170,7 +171,7 @@ object BusinessDocumentDeserializer {
             )
         }
 
-    private fun MsgHead.getMessage(): Dialogmelding? =
+    private fun MsgHead.getMessage(msgHeadXml: String): Dialogmelding? =
         document.firstOrNull()
             ?.refDoc
             ?.content
@@ -178,20 +179,20 @@ object BusinessDocumentDeserializer {
             ?.singleOrNull()
             ?.let {
                 when (it) {
-                    is NhnDialogmelding1_0 -> it.convert()
-                    is NhnDialogmelding1_1 -> it.convert()
+                    is NhnDialogmelding1_0 -> it.convert(msgHeadXml)
+                    is NhnDialogmelding1_1 -> it.convert(msgHeadXml)
                     else -> throw IllegalArgumentException("Unsupported message type: $it")
                 }
             }
 
-    private fun NhnDialogmelding1_0.convert() = Dialogmelding(
+    private fun NhnDialogmelding1_0.convert(msgHeadXml: String) = Dialogmelding(
         foresporsel = readForesporsel(),
-        notat = readNotat(),
+        notat = readNotat(msgHeadXml),
     )
 
-    private fun NhnDialogmelding1_1.convert() = Dialogmelding(
+    private fun NhnDialogmelding1_1.convert(msgHeadXml: String) = Dialogmelding(
         foresporsel = readForesporsel(),
-        notat = readNotat(),
+        notat = readNotat(msgHeadXml),
     )
 
     private fun NhnDialogmelding1_0.readForesporsel(): Foresporsel? =
@@ -205,14 +206,14 @@ object BusinessDocumentDeserializer {
                 )
             }
 
-    private fun NhnDialogmelding1_0.readNotat(): Notat? =
+    private fun NhnDialogmelding1_0.readNotat(msgHeadXml: String): Notat? =
         notat
             ?.singleOrNull()
             ?.let { notat ->
                 Notat(
                     tema = KodeverkRegister.getKodeverk(notat.temaKodet.s, notat.temaKodet.v),
                     temaBeskrivelse = notat.tema,
-                    innhold = notat.tekstNotatInnhold.getText(),
+                    innhold = extractTekstNotatInnhold(msgHeadXml),
                     dato = notat.datoNotat?.toLocalDate(),
                 )
             }
@@ -224,23 +225,56 @@ object BusinessDocumentDeserializer {
                 Foresporsel(
                     type = TypeOpplysningPasientsamhandlingPleieOgOmsorg.entries.firstOrNull { it.verdi == foresporsel.typeForesp.v }
                         ?: throw IllegalArgumentException("Unknown type for typeForesp: ${foresporsel.typeForesp.v}, ${foresporsel.typeForesp.dn}, ${foresporsel.typeForesp.s}, ${foresporsel.typeForesp.ot}"),
-                    sporsmal = foresporsel.sporsmal as? String,
+                    sporsmal = foresporsel.sporsmal as? String, // TODO: anyType, may also be XHTML
                 )
             }
 
-    private fun NhnDialogmelding1_1.readNotat(): Notat? =
+    private fun NhnDialogmelding1_1.readNotat(msgHeadXml: String): Notat? =
         notat
             ?.singleOrNull()
             ?.let { notat ->
                 Notat(
                     tema = KodeverkRegister.getKodeverk(notat.temaKodet.s, notat.temaKodet.v),
                     temaBeskrivelse = notat.tema,
-                    innhold = notat.tekstNotatInnhold.getText(),
+                    innhold = extractTekstNotatInnhold(msgHeadXml),
                     dato = notat.datoNotat?.toLocalDate(),
                 )
             }
 
-    private fun Any?.getText() = (this as? Node)?.firstChild?.nodeValue
+    // Extract the raw XHTML inside the TekstNotatInnhold tag.
+    // No leading or trailing whitespace is removed, as it may be significant in the XHTML content. This also includes indentation.
+    private fun extractTekstNotatInnhold(msgHeadXml: String): String? {
+        val reader = inputFactory.createXMLStreamReader(StringReader(msgHeadXml))
+        try {
+            var depth = 0
+            var contentStart = -1
+            while (reader.hasNext()) {
+                val event = reader.next()
+
+                if (depth > 0 && contentStart < 0) { // We are inside TekstNotatInnhold for the first time
+                    contentStart = reader.location.characterOffset
+                }
+
+                when (event) {
+                    XMLStreamConstants.START_ELEMENT ->
+                        when {
+                            depth > 0 -> depth++ // This is a nested element inside TekstNotatInnhold
+                            reader.localName == TEKST_NOTAT_INNHOLD -> depth = 1 // This is the first TekstNotatInnhold element
+                        }
+
+                    XMLStreamConstants.END_ELEMENT ->
+                        if (depth > 0 && --depth == 0) { // Ignore elements until we are back at depth 0
+                            val contentEnd = reader.location.characterOffset
+                            return msgHeadXml.substring(contentStart, contentEnd)
+                                .takeIf { it.isNotEmpty() }
+                        }
+                }
+            }
+        } finally {
+            reader.close()
+        }
+        return null
+    }
 
     private fun XMLGregorianCalendar.toLocalDate() = toZonedDateTime().withZoneSameInstant(DEFAULT_ZONE).toLocalDate()
 

--- a/msh-client/src/main/kotlin/no/ks/fiks/nhn/edi/BusinessDocumentDeserializer.kt
+++ b/msh-client/src/main/kotlin/no/ks/fiks/nhn/edi/BusinessDocumentDeserializer.kt
@@ -38,7 +38,10 @@ private val log = KotlinLogging.logger { }
 
 object BusinessDocumentDeserializer {
 
-    private val inputFactory = XMLInputFactory.newInstance()
+    private val inputFactory = XMLInputFactory.newInstance().apply {
+        setProperty(XMLInputFactory.SUPPORT_DTD, false)
+        setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false)
+    }
 
     fun deserializeMsgHead(msgHeadXml: String): IncomingBusinessDocument {
         validateRootElement(msgHeadXml, MSG_HEAD_ROOT)
@@ -82,25 +85,33 @@ object BusinessDocumentDeserializer {
     private fun getVersion(xml: String): String? {
         val reader = inputFactory.createXMLStreamReader(StringReader(xml))
 
-        while (reader.hasNext()) {
-            if (reader.next() == XMLStreamConstants.START_ELEMENT) {
-                if (reader.localName == "MIGversion") {
-                    reader.next()
-                    return reader.text
+        try {
+            while (reader.hasNext()) {
+                if (reader.next() == XMLStreamConstants.START_ELEMENT) {
+                    if (reader.localName == "MIGversion") {
+                        reader.next()
+                        return reader.text
+                    }
                 }
             }
+            return null
+        } finally {
+            reader.close()
         }
-        return null
     }
 
     private fun getRootElement(xml: String): String? {
         val reader = inputFactory.createXMLStreamReader(StringReader(xml))
 
-        var iterations = 0
-        while (reader.hasNext() && reader.next() != XMLStreamConstants.START_ELEMENT && iterations < 100) {
-            iterations++
+        try {
+            var iterations = 0
+            while (reader.hasNext() && reader.next() != XMLStreamConstants.START_ELEMENT && iterations < 100) {
+                iterations++
+            }
+            return reader.localName
+        } finally {
+            reader.close()
         }
-        return reader.localName
     }
 
     private fun MsgHead.getType() = msgInfo.type.toMeldingensFunksjon()

--- a/msh-client/src/test/kotlin/no/ks/fiks/nhn/edi/BusinessDocumentDeserializerTest.kt
+++ b/msh-client/src/test/kotlin/no/ks/fiks/nhn/edi/BusinessDocumentDeserializerTest.kt
@@ -10,11 +10,13 @@ import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
+import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
 import no.ks.fiks.hdir.*
 import no.ks.fiks.nhn.msh.*
 import no.ks.fiks.nhn.readResourceContent
 import no.ks.fiks.nhn.readResourceContentAsString
+import org.xml.sax.SAXParseException
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
@@ -534,6 +536,14 @@ class BusinessDocumentDeserializerTest : StringSpec({
 
             it.vedlegg should beNull()
         }
+    }
+
+    "Should throw an exception if TekstNotatInnhold content is invalid" {
+        shouldThrow<SAXParseException> {
+            BusinessDocumentDeserializer.deserializeMsgHead(
+                readResourceContentAsString("dialogmelding/1.1/helsefaglig-dialog/samsvar-test-message-invalid-xhtml.xml")
+            )
+        }.asClue { it.message shouldContain "must be terminated by the matching end-tag" }
     }
 
 })

--- a/msh-client/src/test/kotlin/no/ks/fiks/nhn/edi/BusinessDocumentDeserializerTest.kt
+++ b/msh-client/src/test/kotlin/no/ks/fiks/nhn/edi/BusinessDocumentDeserializerTest.kt
@@ -449,4 +449,93 @@ class BusinessDocumentDeserializerTest : StringSpec({
         }.asClue { it.message shouldBe "Unknown version for AppRec: 123" }
     }
 
+    "Should be able to deserialize Dialogmelding 1.1 Helsefaglig dialog with Notat with XHTML content" {
+        BusinessDocumentDeserializer.deserializeMsgHead(
+            readResourceContentAsString("dialogmelding/1.1/helsefaglig-dialog/samsvar-test-message-xhtml.xml")
+        ).asClue {
+            it.id shouldBe "baec8639-fc76-4c6b-870c-787042e0ada7"
+            it.type shouldBe MeldingensFunksjon.DIALOG_HELSEFAGLIG
+
+            with(it.sender) {
+                parent.name shouldBe "NORSK HELSENETT SF"
+                parent.ids.single().id shouldBe "112374"
+                parent.ids.single().type shouldBe OrganizationIdType.HER_ID
+
+                child.shouldBeInstanceOf<OrganizationCommunicationParty>()
+                with(child) {
+                    name shouldBe "Meldingsvalidering"
+                    ids.single().id shouldBe "8094866"
+                    ids.single().type shouldBe OrganizationIdType.HER_ID
+                }
+            }
+
+            with(it.receiver) {
+                parent.name shouldBe "KS-DIGITALE FELLESTJENESTER AS"
+                parent.ids.single().id shouldBe "8142987"
+                parent.ids.single().type shouldBe OrganizationIdType.HER_ID
+
+                child.shouldBeInstanceOf<PersonCommunicationParty>()
+                with(child) {
+                    firstName shouldBe "Løgnaktig"
+                    middleName should beNull()
+                    lastName shouldBe "Lege"
+                    ids.single().id shouldBe "8144133"
+                    ids.single().type shouldBe PersonIdType.HER_ID
+                }
+            }
+
+            it.message shouldNot beNull()
+            with(it.message!!) {
+                foresporsel should beNull()
+                notat shouldNot beNull()
+                with(notat!!) {
+                    tema shouldBe TemaForHelsefagligDialog.FORESPORSEL_HELSEOPPLYSNINGER
+                    temaBeskrivelse shouldBe "EKG tatt i dag"
+                    dato should beNull()
+
+                    innhold shouldBe """
+                            Leading text without tag
+                            <p>Notat <b>med</b> <i>viktig</i> innhold</p>
+                            <TekstNotatInnhold>
+                                <b>Tekst</b>
+                            </TekstNotatInnhold>
+                            <div xmlns="http://www.w3.org/1999/xhtml">
+                                <h1>Test h1 xhtml</h1>
+                                <p>
+                                    <b>Test bold</b>
+                                </p>
+                                <h2>Test h2 ordered list</h2>
+                                <ol>
+                                    <li>Item
+
+                                    1</li>
+                                    <li>Item 2</li>
+                                    <li>Item 3</li>
+                                </ol>
+                                <table>
+                                    <caption>Test table caption</caption>
+                                    <tr>
+                                        <th>Heading 1</th>
+                                        <th>Heading 2</th>
+                                    </tr>
+                                    <tr>
+                                        <td>Data 1</td>
+                                        <td>Data 2</td>
+                                    </tr>
+                                    <tr>
+                                        <td>Data 3</td>
+                                        <td>Data 4</td>
+                                    </tr>
+                                </table>
+                            </div>
+                        """
+                }
+            }
+
+            it.vedlegg should beNull()
+        }
+    }
+
 })
+
+

--- a/msh-client/src/test/resources/dialogmelding/1.1/helsefaglig-dialog/samsvar-test-message-invalid-xhtml.xml
+++ b/msh-client/src/test/resources/dialogmelding/1.1/helsefaglig-dialog/samsvar-test-message-invalid-xhtml.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- DETTE ER EN TESTMELDING MED FIKTIVE PERSONDATA -->
+<!-- Eksempel på helsefaglig dialog ettersending av informasjon vedr henvisning -->
+<MsgHead xmlns="http://www.kith.no/xmlstds/msghead/2006-05-24" xmlns:xsd="http://www.w3.org/2001/XMLSchema.xsd" xmlns:fk1="http://www.kith.no/xmlstds/felleskomponent1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.kith.no/xmlstds/msghead/2006-05-24 MsgHead-v1_2.xsd">
+    <MsgInfo>
+        <Type V="DIALOG_HELSEFAGLIG" DN="Helsefaglig dialog" />
+        <MIGversion>v1.2 2006-05-24</MIGversion>
+        <GenDate>2026-04-30T10:09:53</GenDate>
+        <MsgId>baec8639-fc76-4c6b-870c-787042e0ada7</MsgId>
+        <ProcessingStatus V="D" DN="Debugging" />
+        <Sender>
+            <Organisation>
+                <OrganisationName>NORSK HELSENETT SF</OrganisationName>
+                <Ident>
+                    <Id>112374</Id>
+                    <TypeId V="HER" DN="HER-id" S="2.16.578.1.12.4.1.1.9051" />
+                </Ident>
+                <Organisation>
+                    <OrganisationName>Meldingsvalidering</OrganisationName>
+                    <Ident>
+                        <Id>8094866</Id>
+                        <TypeId V="HER" DN="HER-id" S="2.16.578.1.12.4.1.1.9051" />
+                    </Ident>
+                </Organisation>
+            </Organisation>
+        </Sender>
+        <Receiver>
+            <Organisation>
+                <OrganisationName>KS-DIGITALE FELLESTJENESTER AS</OrganisationName>
+                <Ident>
+                    <Id>8142987</Id>
+                    <TypeId V="HER" DN="HER-id" S="2.16.578.1.12.4.1.1.9051" />
+                </Ident>
+                <HealthcareProfessional>
+                    <FamilyName>Lege</FamilyName>
+                    <GivenName>Løgnaktig</GivenName>
+                    <Ident>
+                        <Id>8144133</Id>
+                        <TypeId S="2.16.578.1.12.4.1.1.8116" V="HER" DN="HER-id" />
+                    </Ident>
+                </HealthcareProfessional>
+            </Organisation>
+        </Receiver>
+        <Patient>
+            <FamilyName>LENESTOL</FamilyName>
+            <GivenName>BRUN</GivenName>
+            <DateOfBirth>2002-07-15</DateOfBirth>
+            <Ident>
+                <Id>15720255178</Id>
+                <TypeId V="FNR" DN="Fødselsnummer" S="2.16.578.1.12.4.1.1.8116" />
+            </Ident>
+        </Patient>
+    </MsgInfo>
+    <Document>
+        <RefDoc>
+            <IssueDate V="2026-04-30T10:09:53" />
+            <MsgType V="XML" DN="XML-instans" />
+            <Content>
+                <Dialogmelding xmlns="http://www.kith.no/xmlstds/dialog/2013-01-23" xmlns:xsd="http://www.w3.org/2001/XMLSchema.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.kith.no/xmlstds/dialog/2013-01-23 dialogmelding-v1.1.xsd">
+                    <Notat>
+                        <TemaKodet V="8" DN="Forespørsel om helseopplysninger" S="2.16.578.1.12.4.1.1.7322" />
+                        <Tema>EKG tatt i dag</Tema>
+                        <TekstNotatInnhold>
+                            <div xmlns="http://www.w3.org/1999/xhtml">
+                                <h1>Test h1 xhtml</h1>
+                                <p>
+                                    <b>Test bold</b>
+                                </p>
+                                <h2>Test h2 ordered list</h2>
+                                <ol>
+                                    <li>Item
+
+                                    1</li>
+                                    <li>Item 2</li>
+                                    <li>Item 3</li>
+                                </ol>
+                                <table>
+                                    <TekstNotatInnhold>Test table caption</TekstNotatInnhold>
+                                    <tr>
+                                        <th>Heading 1</th>
+                                        <th>Heading 2</th>
+                                    </tr>
+                                    <tr>
+                                        <td>Data 1</td>
+                                        <td>Data 2</td>
+                                    </tr>
+                                    <tr>
+                                        <td>Data 3</td>
+                                        <td>Data 4</td>
+                                    </tr>
+                                </table>
+                            </div>
+                        </TekstNotatInnhold>
+                        <RollerRelatertNotat>
+                            <RoleToPatient DN="Fastlege" V="6" S="2.16.578.1.12.4.1.1.9034" />
+                            <HealthcareProfessional>
+                                <FamilyName>Lege</FamilyName>
+                                <GivenName>Kunstig</GivenName>
+                                <Ident>
+                                    <fk1:Id>9144900</fk1:Id>
+                                    <fk1:TypeId V="HPR" DN="HPR-nummer" S="2.16.578.1.12.4.1.1.8116" />
+                                </Ident>
+                                <TeleCom>
+                                    <fk1:TeleAddress V="tel:12345678"></fk1:TeleAddress>
+                                </TeleCom>
+                            </HealthcareProfessional>
+                        </RollerRelatertNotat>
+                    </Notat>
+                </Dialogmelding>
+            </Content>
+        </RefDoc>
+    </Document>
+</MsgHead>

--- a/msh-client/src/test/resources/dialogmelding/1.1/helsefaglig-dialog/samsvar-test-message-invalid-xhtml.xml
+++ b/msh-client/src/test/resources/dialogmelding/1.1/helsefaglig-dialog/samsvar-test-message-invalid-xhtml.xml
@@ -61,35 +61,7 @@
                         <TemaKodet V="8" DN="Forespørsel om helseopplysninger" S="2.16.578.1.12.4.1.1.7322" />
                         <Tema>EKG tatt i dag</Tema>
                         <TekstNotatInnhold>
-                            <div xmlns="http://www.w3.org/1999/xhtml">
-                                <h1>Test h1 xhtml</h1>
-                                <p>
-                                    <b>Test bold</b>
-                                </p>
-                                <h2>Test h2 ordered list</h2>
-                                <ol>
-                                    <li>Item
-
-                                    1</li>
-                                    <li>Item 2</li>
-                                    <li>Item 3</li>
-                                </ol>
-                                <table>
-                                    <TekstNotatInnhold>Test table caption</TekstNotatInnhold>
-                                    <tr>
-                                        <th>Heading 1</th>
-                                        <th>Heading 2</th>
-                                    </tr>
-                                    <tr>
-                                        <td>Data 1</td>
-                                        <td>Data 2</td>
-                                    </tr>
-                                    <tr>
-                                        <td>Data 3</td>
-                                        <td>Data 4</td>
-                                    </tr>
-                                </table>
-                            </div>
+                            <div xmlns="http://www.w3.org/1999/xhtml"><b></div></b>
                         </TekstNotatInnhold>
                         <RollerRelatertNotat>
                             <RoleToPatient DN="Fastlege" V="6" S="2.16.578.1.12.4.1.1.9034" />

--- a/msh-client/src/test/resources/dialogmelding/1.1/helsefaglig-dialog/samsvar-test-message-xhtml.xml
+++ b/msh-client/src/test/resources/dialogmelding/1.1/helsefaglig-dialog/samsvar-test-message-xhtml.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- DETTE ER EN TESTMELDING MED FIKTIVE PERSONDATA -->
+<!-- Eksempel på helsefaglig dialog ettersending av informasjon vedr henvisning -->
+<MsgHead xmlns="http://www.kith.no/xmlstds/msghead/2006-05-24" xmlns:xsd="http://www.w3.org/2001/XMLSchema.xsd" xmlns:fk1="http://www.kith.no/xmlstds/felleskomponent1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.kith.no/xmlstds/msghead/2006-05-24 MsgHead-v1_2.xsd">
+    <MsgInfo>
+        <Type V="DIALOG_HELSEFAGLIG" DN="Helsefaglig dialog" />
+        <MIGversion>v1.2 2006-05-24</MIGversion>
+        <GenDate>2026-04-30T10:09:53</GenDate>
+        <MsgId>baec8639-fc76-4c6b-870c-787042e0ada7</MsgId>
+        <ProcessingStatus V="D" DN="Debugging" />
+        <Sender>
+            <Organisation>
+                <OrganisationName>NORSK HELSENETT SF</OrganisationName>
+                <Ident>
+                    <Id>112374</Id>
+                    <TypeId V="HER" DN="HER-id" S="2.16.578.1.12.4.1.1.9051" />
+                </Ident>
+                <Organisation>
+                    <OrganisationName>Meldingsvalidering</OrganisationName>
+                    <Ident>
+                        <Id>8094866</Id>
+                        <TypeId V="HER" DN="HER-id" S="2.16.578.1.12.4.1.1.9051" />
+                    </Ident>
+                </Organisation>
+            </Organisation>
+        </Sender>
+        <Receiver>
+            <Organisation>
+                <OrganisationName>KS-DIGITALE FELLESTJENESTER AS</OrganisationName>
+                <Ident>
+                    <Id>8142987</Id>
+                    <TypeId V="HER" DN="HER-id" S="2.16.578.1.12.4.1.1.9051" />
+                </Ident>
+                <HealthcareProfessional>
+                    <FamilyName>Lege</FamilyName>
+                    <GivenName>Løgnaktig</GivenName>
+                    <Ident>
+                        <Id>8144133</Id>
+                        <TypeId S="2.16.578.1.12.4.1.1.8116" V="HER" DN="HER-id" />
+                    </Ident>
+                </HealthcareProfessional>
+            </Organisation>
+        </Receiver>
+        <Patient>
+            <FamilyName>LENESTOL</FamilyName>
+            <GivenName>BRUN</GivenName>
+            <DateOfBirth>2002-07-15</DateOfBirth>
+            <Ident>
+                <Id>15720255178</Id>
+                <TypeId V="FNR" DN="Fødselsnummer" S="2.16.578.1.12.4.1.1.8116" />
+            </Ident>
+        </Patient>
+    </MsgInfo>
+    <Document>
+        <RefDoc>
+            <IssueDate V="2026-04-30T10:09:53" />
+            <MsgType V="XML" DN="XML-instans" />
+            <Content>
+                <Dialogmelding xmlns="http://www.kith.no/xmlstds/dialog/2013-01-23" xmlns:xsd="http://www.w3.org/2001/XMLSchema.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.kith.no/xmlstds/dialog/2013-01-23 dialogmelding-v1.1.xsd">
+                    <Notat>
+                        <TemaKodet V="8" DN="Forespørsel om helseopplysninger" S="2.16.578.1.12.4.1.1.7322" />
+                        <Tema>EKG tatt i dag</Tema>
+                        <TekstNotatInnhold>
+                            Leading text without tag
+                            <p>Notat <b>med</b> <i>viktig</i> innhold</p>
+                            <TekstNotatInnhold>
+                                <b>Tekst</b>
+                            </TekstNotatInnhold>
+                            <div xmlns="http://www.w3.org/1999/xhtml">
+                                <h1>Test h1 xhtml</h1>
+                                <p>
+                                    <b>Test bold</b>
+                                </p>
+                                <h2>Test h2 ordered list</h2>
+                                <ol>
+                                    <li>Item
+
+                                    1</li>
+                                    <li>Item 2</li>
+                                    <li>Item 3</li>
+                                </ol>
+                                <table>
+                                    <caption>Test table caption</caption>
+                                    <tr>
+                                        <th>Heading 1</th>
+                                        <th>Heading 2</th>
+                                    </tr>
+                                    <tr>
+                                        <td>Data 1</td>
+                                        <td>Data 2</td>
+                                    </tr>
+                                    <tr>
+                                        <td>Data 3</td>
+                                        <td>Data 4</td>
+                                    </tr>
+                                </table>
+                            </div>
+                        </TekstNotatInnhold>
+                        <RollerRelatertNotat>
+                            <RoleToPatient DN="Fastlege" V="6" S="2.16.578.1.12.4.1.1.9034" />
+                            <HealthcareProfessional>
+                                <FamilyName>Lege</FamilyName>
+                                <GivenName>Kunstig</GivenName>
+                                <Ident>
+                                    <fk1:Id>9144900</fk1:Id>
+                                    <fk1:TypeId V="HPR" DN="HPR-nummer" S="2.16.578.1.12.4.1.1.8116" />
+                                </Ident>
+                                <TeleCom>
+                                    <fk1:TeleAddress V="tel:12345678"></fk1:TeleAddress>
+                                </TeleCom>
+                            </HealthcareProfessional>
+                        </RollerRelatertNotat>
+                    </Notat>
+                </Dialogmelding>
+            </Content>
+        </RefDoc>
+    </Document>
+</MsgHead>


### PR DESCRIPTION
The `TekstNotatInnhold` XML element is of `anyType`, and may contain XHTML:
> Felt for det tekstlige innholdet i notatet. Enkel formatering iht lovlige Xhtml-koder kan benyttes.

These changes make sure the content is extracted and put into the expected field.